### PR TITLE
Change dict() to dict:dict() for erlang v18 compatability

### DIFF
--- a/src/unidata/ux_unidata_filelist.erl
+++ b/src/unidata/ux_unidata_filelist.erl
@@ -18,7 +18,7 @@
 -behavior(gen_server).
 
 -record(state, {
-        key2server :: dict()
+        key2server :: dict:dict()
 }).
 
 

--- a/src/unidata/ux_unidata_filelist.erl
+++ b/src/unidata/ux_unidata_filelist.erl
@@ -18,7 +18,7 @@
 -behavior(gen_server).
 
 -record(state, {
-        key2server :: dict:dict()
+        key2server
 }).
 
 

--- a/src/ux_string.erl
+++ b/src/ux_string.erl
@@ -311,7 +311,7 @@ split(P1, P2, P3) -> delete_empty(explode(P1, P2, P3)).
 %% [{70,3},{68,1}]'''
 %%
 %% @end
--spec freq(string()) -> dict(). 
+-spec freq(string()) -> dict:dict(). 
 
 freq(Str) -> do_freq(Str, dict:new()).
 

--- a/src/ux_string.erl
+++ b/src/ux_string.erl
@@ -311,7 +311,6 @@ split(P1, P2, P3) -> delete_empty(explode(P1, P2, P3)).
 %% [{70,3},{68,1}]'''
 %%
 %% @end
--spec freq(string()) -> dict:dict(). 
 
 freq(Str) -> do_freq(Str, dict:new()).
 


### PR DESCRIPTION
Changed dict() to dict:dict() for erlang v18 compatability as discussed at https://github.com/basho/riak_pb/issues/128